### PR TITLE
page title/logo should link to the home page

### DIFF
--- a/www/attachments/index.html
+++ b/www/attachments/index.html
@@ -17,7 +17,7 @@
   
   <body>
     <div id="body-container">
-      <div id="title">npm registry</div>
+      <div id="title"><a href="http://search.npmjs.org" title="Home">npm registry</a></div>
       <div id="totals"></div>
       
       <div id="content"></div>


### PR DESCRIPTION
May be I'm doing this wrong, but there was no way to go back to the "home page" (ie., the search box) from a child pages.

By convention, the title of the website links to the home page, which is what I've done.

HTH.
