### PR TITLE
Make repository listing more robust, fixed display of licenses and engines

### DIFF
--- a/www/attachments/site.js
+++ b/www/attachments/site.js
@@ -465,30 +465,30 @@ app.showPackage = function () {
         $('div#version-info').append(bugs)
       }
       if (v.engines) {
+	    var eng = [];
+        for (i in v.engines) { eng.push( i + ' (' + v.engines[i] + ')' ); }
         $(
           '<div class="version-info-cell">' +
-            '<div class="version-info-key">Engines</div>' +
-            '<div class="version-info-value">'+JSON.stringify(v.engines)+'</div>' +
+            '<div class="version-info-key">Licenses</div>' +
+            '<div class="version-info-value">'+eng.join(', ')+'</div>' +
           '</div>' +
           '<div class="spacer"></div>'
-        )
-        .appendTo('div#version-info')
+        ).appendTo('div#version-info');
       }
       if (v.licenses) {
-        var lic = $(
+	    h = '';
+        for (i in v.licenses) {
+          h += '<a href="'+v.licenses[i].url+'">'+v.licenses[i].type+'</a>';
+        }
+        $(
           '<div class="version-info-cell">' +
             '<div class="version-info-key">Licenses</div>' +
-            '<div class="version-info-value">'+JSON.stringify(v.engines)+'</div>' +
+            '<div class="version-info-value">'+h+'</div>' +
           '</div>' +
           '<div class="spacer"></div>'
-        )
-        for (i in v.licenses) {
-          lic.find('div.version-info-value').html(
-            '<a href="'+v.licenses[i].url+'">'+v.licenses[i].type+'</a>'
-          )
-        }
-        lic.appendTo('div#version-info')
+        ).appendTo('div#version-info');
       }
+
       
       //  +
       // '<div class="version-info-cell">' +


### PR DESCRIPTION
When package.json contains a repository info like `"repository": "<url to repository>"`, the search result displays `"undefined: undefined"`. The fix takes this into account.

Optimized display of licenses and added display of engines (instead of just JSON.stringify() them).
