### PR TITLE
Fixing a typo in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ as the JSON body of the request. MUST have `content-type:application/json`
 
 Link a distribution tag (ie. "latest") to a specific version string.
 
-MUST but a JSON string as the body. Example:
+MUST be a JSON string as the body. Example:
 
     "0.1.2"
 


### PR DESCRIPTION
Fixed a typo, was but should have been be.
