### PR TITLE
Bug in url building for doc.versions[v].dist.tarball

### DIFF
--- a/registry/app.js
+++ b/registry/app.js
@@ -881,7 +881,7 @@ ddoc.shows.package = function (doc, req) {
                              .concat(["_rewrite"]).join("/")
         }
 
-        var h = "http://" + req.headers.Host
+        var h = "http://" + req.headers.Host + "/"
 
         doc.versions[v].dist.tarball = h + basePath + t
       }


### PR DESCRIPTION
Attached patch adds a trailing slash to the host when building tarball urls, so we don't end up with urls like 

```
http://lolcathost:5984registry/..
```

but with

```
http://lolcathost:5984/registry/..
```
