### PR TITLE
Error: "Object.keys is not a function" on gecko < 2.0

### DIFF
--- a/registry/app.js
+++ b/registry/app.js
@@ -818,11 +818,11 @@ ddoc.shows.package = function (doc, req) {
       return d.getTime()
       return [d.getTime(), d.toUTCString(), ds, ts, tz]
     }
-    Object.keys = Object.keys
-      || function (o) { var a = []
-                        for (var i in o) a.push(i)
-                        return a }
   }
+  Object.keys = Object.keys
+    || function (o) { var a = []
+                      for (var i in o) a.push(i)
+                      return a }
 
   var semver = require("semver")
     , code = 200
@@ -959,11 +959,11 @@ ddoc.updates.package = function (doc, req) {
       return d.getTime()
       return [d.getTime(), d.toUTCString(), ds, ts, tz]
     }
-    Object.keys = Object.keys
-      || function (o) { var a = []
-                        for (var i in o) a.push(i)
-                        return a }
   }
+  Object.keys = Object.keys
+    || function (o) { var a = []
+                      for (var i in o) a.push(i)
+                      return a }
 
   var semver = require("semver")
   var valid = require("valid")
@@ -1119,11 +1119,11 @@ ddoc.validate_doc_update = function (newDoc, oldDoc, user) {
       return d.getTime()
       return [d.getTime(), d.toUTCString(), ds, ts, tz]
     }
-    Object.keys = Object.keys
-      || function (o) { var a = []
-                        for (var i in o) a.push(i)
-                        return a }
   }
+  Object.keys = Object.keys
+    || function (o) { var a = []
+                      for (var i in o) a.push(i)
+                      return a }
 
   Array.isArray = Array.isArray
     || function (a) { return a instanceof Array


### PR DESCRIPTION
In my ongoing endeavor to replace my buggy S3-backed npm registry that lacks some query capabilities, I found the following:

`shows.package` gives me 500 with this response:

```
{
error: "render_error"
reason: "function raised error: (new TypeError("Object.keys is not a function", "", 44)) 
stacktrace: ([object Object],[object Object])@:44
runShow(function (doc, req) {if (!Date.prototype.toISOString) {
function ISODateString(d) {
function pad(n) {return n < 10 ? "0" + n : n;}

return d.getUTCFullYear() + "-" + pad(d.getUTCMonth() + 1) + "-" + pad(d.getUTCDate()) + "T" + pad(d.getUTCHours()) + ":" + pad(d.getUTCMinutes()) + ":" + pad(d.getUTCSeconds()) + "Z";}

Date.prototype.toISOString = function () {return ISODateString(this);};Date.parse = function (s) {s = s.split("T");var ds = s[0], ts = s[1], d = new Date;ds = ds.split("-");ts = ts.split(":");var tz = ts[2].substr(2);ts[2] = ts[2].substr(0, 2);d.setUTCFullYear(+ ds[0]);d.setUTCMonth(+ ds[1] - 1);d.setUTCDate(+ ds[2]);d.setUTCHours(+ ts[0]);d.setUTCMinutes(+ ts[1]);d.setUTCSeconds(+ ts[2]);d.setUTCMilliseconds(0);return d.getTime();return [d.getTime(), d.toUTCString(), ds, ts, tz];};Object.keys = Object.keys || function (o) {var a = [];for (var i in o) {a.push(i);}return a;};}var semver = require("semver"), code = 200, headers = {'Content-Type': "application/json"}, body = null;delete doc.ctime;delete doc.mtime;if (doc.versions) {Object.keys(doc.versions).forEach(function (v) {delete doc.versions[v].ctime;delete doc.versions[v].mtime;});}if (doc.url) {var url = doc.url;if (req.query.version) {url += "/" + req.query.version;}headers.Location = url;body = {location: url, _rev: doc._rev};body = req.query.jsonp ? req.query.jsonp + "(" + JSON.stringify(body) + ")" : JSON.stringify(body);return {code: 301, body: body, headers: headers};}if (doc.versions) {for (var v in doc.versions) {var clean = semver.clean(v);doc.versions[v].directories = doc.versions[v].directories || {};if (clean !== v) {var p = doc.versions[v];delete doc.versions[v];p.version = v = clean;doc.versions[clean] = p;}if (doc.versions[v].dist.tarball) {var t = doc.versions[v].dist.tarball;t = t.replace(/^https?:\/\/[^\/:]+(:[0-9]+)?/, "");if (!t.match(/^\/[^\/]+\/_design\/app\/_rewrite/)) {doc.versions[v].dist.tarball = t;var basePath = req.requested_path;if (basePath.indexOf("_show") === -1) {basePath = "";} else {basePath = "/" + basePath.slice(0, basePath.indexOf("_show")).concat(["_rewrite"]).join("/");}var h = "http://" + req.headers.Host;doc.versions[v].dist.tarball = h + basePath + t;}}}}if (doc['dist-tags']) {for (var tag in doc['dist-tags']) {var clean = semver.clean(doc['dist-tags'][tag]);if (!clean) {delete doc['dist-tags'][tag];} else {doc['dist-tags'][tag] = clean;}}}if (req.query.version) {var ver = req.query.version;if (!(ver in doc.versions) && ver in doc['dist-tags'] || !semver.valid(ver)) {ver = doc['dist-tags'][ver];}body = doc.versions[ver];if (!body) {code = 404;body = {error: "version not found: " + req.query.version};}} else {body = doc;for (var i in body) {if (i.charAt(0) === "_" && i !== "_id" && i !== "_rev") {delete body[i];}}for (var i in body.time) {if (!body.versions[i]) {delete body.time[i];} else {body.time[i] = (new Date(Date.parse(body.time[i]))).toISOString();}}}body = req.query.jsonp ? req.query.jsonp + "(" + JSON.stringify(body) + ")" : toJSON(body);return {code: code, body: body, headers: headers};},[object Object],[object Array])@/usr/local/share/couchdb/server/main.js:887
(function (doc, req) {if (!Date.prototype.toISOString) {
function ISODateString(d) {
function pad(n) {return n < 10 ? "0" + n : n;}

return d.getUTCFullYear() + "-" + pad(d.getUTCMonth() + 1) + "-" + pad(d.getUTCDate()) + "T" + pad(d.getUTCHours()) + ":" + pad(d.getUTCMinutes()) + ":" + pad(d.getUTCSeconds()) + "Z";}

Date.prototype.toISOString = function () {return ISODateString(this);};Date.parse = function (s) {s = s.split("T");var ds = s[0], ts = s[1], d = new Date;ds = ds.split("-");ts = ts.split(":");var tz = ts[2].substr(2);ts[2] = ts[2].substr(0, 2);d.setUTCFullYear(+ ds[0]);d.setUTCMonth(+ ds[1] - 1);d.setUTCDate(+ ds[2]);d.setUTCHours(+ ts[0]);d.setUTCMinutes(+ ts[1]);d.setUTCSeconds(+ ts[2]);d.setUTCMilliseconds(0);return d.getTime();return [d.getTime(), d.toUTCString(), ds, ts, tz];};Object.keys = Object.keys || function (o) {var a = [];for (var i in o) {a.push(i);}return a;};}var semver = require("semver"), code = 200, headers = {'Content-Type': "application/json"}, body = null;delete doc.ctime;delete doc.mtime;if (doc.versions) {Object.keys(doc.versions).forEach(function (v) {delete doc.versions[v].ctime;delete doc.versions[v].mtime;});}if (doc.url) {var url = doc.url;if (req.query.version) {url += "/" + req.query.version;}headers.Location = url;body = {location: url, _rev: doc._rev};body = req.query.jsonp ? req.query.jsonp + "(" + JSON.stringify(body) + ")" : JSON.stringify(body);return {code: 301, body: body, headers: headers};}if (doc.versions) {for (var v in doc.versions) {var clean = semver.clean(v);doc.versions[v].directories = doc.versions[v].directories || {};if (clean !== v) {var p = doc.versions[v];delete doc.versions[v];p.version = v = clean;doc.versions[clean] = p;}if (doc.versions[v].dist.tarball) {var t = doc.versions[v].dist.tarball;t = t.replace(/^https?:\/\/[^\/:]+(:[0-9]+)?/, "");if (!t.match(/^\/[^\/]+\/_design\/app\/_rewrite/)) {doc.versions[v].dist.tarball = t;var basePath = req.requested_path;if (basePath.indexOf("_show") === -1) {basePath = "";} else {basePath = "/" + basePath.slice(0, basePath.indexOf("_show")).concat(["_rewrite"]).join("/");}var h = "http://" + req.headers.Host;doc.versions[v].dist.tarball = h + basePath + t;}}}}if (doc['dist-tags']) {for (var tag in doc['dist-tags']) {var clean = semver.clean(doc['dist-tags'][tag]);if (!clean) {delete doc['dist-tags'][tag];} else {doc['dist-tags'][tag] = clean;}}}if (req.query.version) {var ver = req.query.version;if (!(ver in doc.versions) && ver in doc['dist-tags'] || !semver.valid(ver)) {ver = doc['dist-tags'][ver];}body = doc.versions[ver];if (!body) {code = 404;body = {error: "version not found: " + req.query.version};}} else {body = doc;for (var i in body) {if (i.charAt(0) === "_" && i !== "_id" && i !== "_rev") {delete body[i];}}for (var i in body.time) {if (!body.versions[i]) {delete body.time[i];} else {body.time[i] = (new Date(Date.parse(body.time[i]))).toISOString();}}}body = req.query.jsonp ? req.query.jsonp + "(" + JSON.stringify(body) + ")" : toJSON(body);return {code: code, body: body, headers: headers};},[object Object],[object Array])@/usr/local/share/couchdb/server/main.js:990
("_design/app",[object Array],[object Array])@/usr/local/share/couchdb/server/main.js:1431
()@/usr/local/share/couchdb/server/main.js:1474
@/usr/local/share/couchdb/server/main.js:1485
"
}
```

Attached patch adds the Object.keys shim also, when there is Date.prototype.toISOString but not Object.keys (That is the case if CouchDB runs against a Gecko 1.9.2 (Firefox 3)).
