### PR TITLE
Override Date.parse if it doesn't parse iso8859

### DIFF
--- a/registry/app.js
+++ b/registry/app.js
@@ -46,6 +46,8 @@ ddoc.shows.requirey = function () {
         + pad(d.getUTCSeconds())+'Z'}
   if (!Date.prototype.toISOString) {
     Date.prototype.toISOString = function () { return ISODateString(this) }
+  }
+  if (isNaN(Date.parse("2010-12-29T07:31:06Z"))) {
     Date.parse = function (s) {
       // s is something like "2010-12-29T07:31:06Z"
       s = s.split("T")
@@ -277,6 +279,8 @@ ddoc.lists.index = function (head, req) {
         + pad(d.getUTCSeconds())+'Z'}
   if (!Date.prototype.toISOString) {
     Date.prototype.toISOString = function () { return ISODateString(this) }
+  }
+  if (isNaN(Date.parse("2010-12-29T07:31:06Z"))) {
     Date.parse = function (s) {
       // s is something like "2010-12-29T07:31:06Z"
       s = s.split("T")
@@ -800,6 +804,8 @@ ddoc.shows.package = function (doc, req) {
            + pad(d.getUTCMinutes())+':'
            + pad(d.getUTCSeconds())+'Z'}
     Date.prototype.toISOString = function () { return ISODateString(this) }
+  }
+  if (isNaN(Date.parse("2010-12-29T07:31:06Z"))) {
     Date.parse = function (s) {
       // s is something like "2010-12-29T07:31:06Z"
       s = s.split("T")
@@ -941,6 +947,8 @@ ddoc.updates.package = function (doc, req) {
         + pad(d.getUTCSeconds())+'Z'}
   if (!Date.prototype.toISOString) {
     Date.prototype.toISOString = function () { return ISODateString(this) }
+  }
+  if (isNaN(Date.parse("2010-12-29T07:31:06Z"))) {
     Date.parse = function (s) {
       // s is something like "2010-12-29T07:31:06Z"
       s = s.split("T")
@@ -1102,6 +1110,8 @@ ddoc.validate_doc_update = function (newDoc, oldDoc, user) {
         + pad(d.getUTCSeconds())+'Z'}
   if (!Date.prototype.toISOString) {
     Date.prototype.toISOString = function () { return ISODateString(this) }
+  }
+  if (isNaN(Date.parse("2010-12-29T07:31:06Z"))) {
     Date.parse = function (s) {
       // s is something like "2010-12-29T07:31:06Z"
       s = s.split("T")


### PR DESCRIPTION
The registry relies on parsing iso8859 dates and adds a shim when the underlying JavaScript engine doesn't support that.

Attached patch changes when to use the shim from

```
!Date.prototype.toISOString
```

to

```
isNaN(Date.parse("2010-12-29T07:31:06Z"))
```

Without this, I get the following error on my machine (Ubuntu Lucid (current vagrant basebox) with CouchDB 1.1.0 and xulrunner 1.9.2.18) when using `npm publish`

```
npm sill chunk {"error":"forbidden","reason":"invalid created/modified time: {\"modified\":\"2011-07-31T17:19:46.048Z\",\"created\":\"2011-07-31T17:19:46.048Z\"} Invalid Date Invalid Date"}
npm sill chunk 
npm ERR! Failed PUT response 403
```

so long,
Filip
