### PR TITLE
Add OpenSearch Support

### DIFF
--- a/www/attachments/index.html
+++ b/www/attachments/index.html
@@ -12,6 +12,9 @@
     <link rel="alternate" type="application/rss+xml"
       href="/api/_design/app/_rewrite/-/rss?descending=true&limit=50"
       title="npm publish feed (RSS)">
+    <link rel="search" type="application/opensearchdescription+xml"
+      href="/opensearch.xml"
+      title="npm">
     <script language="javascript" type="text/javascript" src="jquery-1.4.4.min.js"></script>
     <script language="javascript" type="text/javascript" src="sammy/sammy.js"></script>
     <script language="javascript" type="text/javascript" src="site.js"></script>

--- a/www/attachments/opensearch.xml
+++ b/www/attachments/opensearch.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>npm</ShortName>
+  <Description>A package manager for node.</Description>
+  <Contact>npm-@googlegroups.com</Contact>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Url type="text/html" template="http://search.npmjs.org/#/?q={searchTerms}" />
+</OpenSearchDescription>

--- a/www/attachments/site.js
+++ b/www/attachments/site.js
@@ -122,32 +122,37 @@ app.index = function () {
       '<div class="spacer"></div>' +
     '</div>'
   )
-  
-  request({url:'/api/_all_docs?limit=0'}, function (err, resp) {
-    $('div#totals').html('<a href="/#/_browse/all">' + (resp.total_rows - 1) +' total packages</a>')
-  })
-  
-  request({url:'/_view/updated?descending=true&limit='+limit+'&include_docs=false'}, function (err, resp) {
-    resp.rows.forEach(function (row) {
-      $('<div class="top-package"></div>')
-      .append('<div class="top-package-title"><a href="#/'+row.id+'">'+row.id+'</a></div>')
-      .append('<div class="top-package-updated">'+prettyDate(row.key) +'</div>')
-      .append('<div class="spacer"></div>')
-      .appendTo('div#latest-packages')
+
+  if (this.params.q) {
+    $('div#top-packages').hide();
+    currentSearch = decodeURIComponent(this.params.q.replace(/\+/g, '%20'));
+  } else {
+    request({url:'/api/_all_docs?limit=0'}, function (err, resp) {
+      $('div#totals').html('<a href="/#/_browse/all">' + (resp.total_rows - 1) +' total packages</a>')
     })
-  })
-  
-  request({url:'/_list/dependencies_limit/dependencies?group=true&descending=true&list_limit='+limit}, function (err, resp) {
-    var results = {};
-    resp.rows.forEach(function (row) {
-        $('<div class="top-package"></div>')
-        .append('<div class="top-package-title"><a href="#/'+row.key+'">'+row.key+'</a></div>')
-        .append('<div class="top-package-dep">'+row.value+'</div>')
-        .append('<div class="spacer"></div>')
-        .appendTo('div#top-dep-packages')
-    })
-  })
     
+    request({url:'/_view/updated?descending=true&limit='+limit+'&include_docs=false'}, function (err, resp) {
+      resp.rows.forEach(function (row) {
+        $('<div class="top-package"></div>')
+        .append('<div class="top-package-title"><a href="#/'+row.id+'">'+row.id+'</a></div>')
+        .append('<div class="top-package-updated">'+prettyDate(row.key) +'</div>')
+        .append('<div class="spacer"></div>')
+        .appendTo('div#latest-packages')
+      })
+    })
+    
+    request({url:'/_list/dependencies_limit/dependencies?group=true&descending=true&list_limit='+limit}, function (err, resp) {
+      var results = {};
+      resp.rows.forEach(function (row) {
+          $('<div class="top-package"></div>')
+          .append('<div class="top-package-title"><a href="#/'+row.key+'">'+row.key+'</a></div>')
+          .append('<div class="top-package-dep">'+row.value+'</div>')
+          .append('<div class="spacer"></div>')
+          .appendTo('div#top-dep-packages')
+      })
+    })
+  }
+
   var updateResults = function () {
     currentSearch = $('input#search-input').val().toLowerCase();
     currentTerms = $.trim(currentSearch).split(' ');
@@ -298,6 +303,10 @@ app.index = function () {
   $('input#search-input').change(handleChange);
   $('input#search-input').keyup(handleChange)
   $("input#search-input").focus();
+
+  if (currentSearch) {
+    $('input#search-input').val(currentSearch).change();
+  }
 };
 
 app.showPackage = function () {


### PR DESCRIPTION
This pull request adds basic OpenSearch support and includes three main changes:
1. Conditionally load the first three requests in the index route (indention messes with the diff, looking directly at the code makes the change more clear)
2. If the "q" parameter is added to the index route (ex: /#/q=express): decode it, assign it to currentSearch and manually trigger handleChange
3. Add opensearch.xml and link in the html
