### PR TITLE
Missing doc reference

### DIFF
--- a/www/attachments/site.js
+++ b/www/attachments/site.js
@@ -596,7 +596,7 @@ app.browse = function () {
       , function (r) {
         var h = ''
         r.rows.forEach(function (row) {
-        row.htmlDescription = row.description.split('&').join('&amp;')
+        row.doc.htmlDescription = row.doc.description.split('&').join('&amp;')
                                              .split('"').join('&quot;')
                                              .split('<').join('&lt;')
                                              .split('>').join('&gt;')


### PR DESCRIPTION
I noticed http://search.npmjs.org/#/_browse/all was blank.  Chrome was throwing a javascript error. I debugged it and saw that line 599 was missing the reference to the doc property.
