### PR TITLE
Check for doc.description before calling string methods on it.

### DIFF
--- a/www/attachments/site.js
+++ b/www/attachments/site.js
@@ -709,10 +709,14 @@ app.tags = function () {
   .append('<div id="main-container"></div>');
   request({url:'/_view/tags?reduce=false&include_docs=true&key="'+tag+'"'}, function (e, resp) {
     resp.rows.forEach(function (row) {
+      if (row.doc.description) {
         row.doc.htmlDescription = row.doc.description.split('&').join('&amp;')
                                              .split('"').join('&quot;')
                                              .split('<').join('&lt;')
                                              .split('>').join('&gt;')
+      } else {
+        row.doc.htmlDescription = ''
+      }
       $('div#main-container').append(
         '<div class="all-package">' + 
           '<div class="tags-pkg-name"><a href="/#/'+encodeURIComponent(row.key)+'">' + row.id + '</a></div>' +
@@ -732,10 +736,14 @@ app.author = function () {
   .append('<div id="main-container"></div>');
   request({url:'/_view/author?reduce=false&include_docs=true&key="'+author+'"'}, function (e, resp) {
     resp.rows.forEach(function (row) {
+      if (row.doc.description) {
         row.doc.htmlDescription = row.doc.description.split('&').join('&amp;')
                                              .split('"').join('&quot;')
                                              .split('<').join('&lt;')
                                              .split('>').join('&gt;')
+      } else {
+        row.doc.htmlDescription = ''
+      }
       $('div#main-container').append(
         '<div class="all-package">' + 
           '<div class="tags-pkg-name"><a href="/#/'+encodeURIComponent(row.id)+'">' + row.id + '</a></div>' +


### PR DESCRIPTION
There are times when a package does not have a `description` property in CouchDB. Unfortunately, the client app assumes this property exists and is a string, so calls the `split` method on it. This throws an error.

For example, try viewing all packages by @mde:

http://search.npmjs.org/#/_author/Matthew%20Eernisse

The page will never load, as neither of the package.json files for his modules contain a `description` property:

https://github.com/mde/geddy/blob/master/package.json
https://github.com/mde/jake/blob/master/package.json

This pull request checks for the `description` property before using it.
