### PR TITLE
Fix loop control corruption during _npmUser validation

### DIFF
--- a/registry/validate_doc_update.js
+++ b/registry/validate_doc_update.js
@@ -255,8 +255,8 @@ module.exports = function (doc, oldDoc, user, dbCtx) {
 
       // make sure that the _npmUser is one of the maintainers
       var found = false
-      for (var i = 0, l = doc.maintainers.length; i < l; i ++) {
-        var m = doc.maintainers[i]
+      for (var j = 0, lm = doc.maintainers.length; j < lm; j ++) {
+        var m = doc.maintainers[j]
         if (m.name === doc.versions[v]._npmUser.name) {
           found = true
           break


### PR DESCRIPTION
The validation of versions includes a nested loop to validate _npmUser, and that inner loop reuses the same control vars as the outer loop. This causes corruption of the loop control, sometimes causing an infinite loop, and eventually a timeout error. The patch simply uses different names for the inner loop control vars.
