### PR TITLE
Markup for homepage link in package description. Fixes #13 (at least partially).

### DIFF
--- a/www/attachments/site.js
+++ b/www/attachments/site.js
@@ -435,7 +435,7 @@ app.showPackage = function () {
         $('div#version-info').append(
           '<div class="version-info-cell">' +
             '<div class="version-info-key">Homepage</div>' +
-            '<div class="version-info-value">' + escapeHTML(v.homepage) + '</div>' +
+            '<div class="version-info-value"><a href="' + escapeHTML(v.homepage) + '">' + escapeHTML(v.homepage) + '</a></div>' +
           '</div>' +
           '<div class="spacer"></div>'
         )


### PR DESCRIPTION
The npm registry package description often contains a link but it's plain text. _So_ annoying.
