### PR TITLE
Add `created` view

### DIFF
--- a/registry/views.js
+++ b/registry/views.js
@@ -11,6 +11,16 @@ views.listAll = {
   map : function (doc) { return emit(doc._id, doc) }
 }
 
+views.created = { map: createdTimeMap }
+function createdTimeMap (doc) {
+  if (!doc.versions || doc.deprecated) return
+  var first = doc.versions[0]
+  if (!first) return
+  var time = doc.time && doc.time[first] || 0
+  var t = new Date(time)
+  emit(t.getTime(), doc)
+}
+
 views.modified = { map: modifiedTimeMap }
 function modifiedTimeMap (doc) {
   if (!doc.versions || doc.deprecated) return


### PR DESCRIPTION
Would be great to have a `created` view, so that we could add a RSS feed for new modules and have a list on the front-page for it.

I wasn't able to set up the registry locally, so not tested...
