### PR TITLE
registry: don't require username when validating

### DIFF
--- a/registry/validate_doc_update.js
+++ b/registry/validate_doc_update.js
@@ -4,13 +4,7 @@ module.exports = function (doc, oldDoc, user, dbCtx) {
   }
 
   // can't write to the db without logging in.
-  var userName
-  try {
-    userName = user && user.name
-  } catch (er) {
-    assert(false, "failed checking user.name")
-  }
-  if (!userName) {
+  if (!user) {
     throw { unauthorized: "Please log in before writing to the db" }
   }
 


### PR DESCRIPTION
Checking `user` should be enough to verify if user is logged or not.

Issue with this check arose when replicating public npm registry to a
public one. When using `_replicator` database it is not required to
define username for replicator's `user_ctx` (`{ "roles": ["_admin"] }`)
is enough.

`userName` variable isn't used further down either.
