### PR TITLE
reorder setup steps: replicate before pushing apps to skip validate_doc_update functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,6 @@ Now install couchapp and semver:
     npm install couchapp
     npm install semver
 
-Sync the registry and search:
-
-    couchapp push registry/app.js http://localhost:5984/registry
-    couchapp push www/app.js http://localhost:5984/registry
-
-You may need to put a username and password in the URL:
-
-    couchapp push www/app.js http://user:pass@localhost:5984/registry
-    couchapp push registry/app.js http://user:pass@localhost:5984/registry
-
 To synchronize from the public npm registry to your private registry,
 create a replication task from http://isaacs.ic.ht/registry --> local
 database registry. This can be done through Futon (the CouchDB administrative
@@ -42,6 +32,16 @@ UI) or via an HTTP call to '/_replicate like so:
     curl -X POST -H "Content-Type:application/json" \
         http://localhost:5984/_replicate -d \
         '{"source":"http://isaacs.iriscouch.com/registry/", "target":"registry"}'
+
+Push the the registry and search apps:
+
+    couchapp push registry/app.js http://localhost:5984/registry
+    couchapp push www/app.js http://localhost:5984/registry
+
+You may need to put a username and password in the URL:
+
+    couchapp push www/app.js http://user:pass@localhost:5984/registry
+    couchapp push registry/app.js http://user:pass@localhost:5984/registry
 
 # Using the registry with the npm client
 


### PR DESCRIPTION
makes for a faster and less CPU intensive replication and should produce a functionally equivalent result
