### PR TITLE
Update couchapp to ~0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "copy": "./copy.sh"
   },
   "dependencies": {
-    "couchapp": "~0.9",
+    "couchapp": "~0.10",
     "semver": "~2.0.10"
   },
   "devDependencies": {


### PR DESCRIPTION
The 0.9 series of couchapp has a bug that throws an exception in non-OSX 
systems.
