### PR TITLE
make inline attachments possible

### DIFF
--- a/registry/updates.js
+++ b/registry/updates.js
@@ -110,6 +110,19 @@ updates.package = function (doc, req) {
       if (!doc.users) doc.users = {}
       doc.users[req.userCtx.name] = newdoc.users[req.userCtx.name]
     }
+
+    if(newdoc._attachments) {
+      var inline = false
+      for(var k in newdoc._attachments) {
+        if(newdoc._attachments[k].data) {
+          doc._attachments[k] = newdoc._attachments[k]
+          inline = true
+        }
+      }
+      if(inline)
+        return ok(doc, "updated package metadata & attachments")
+    }
+
     return ok(doc, "updated package metadata")
   } else {
     // Create new package doc
@@ -127,6 +140,7 @@ updates.package = function (doc, req) {
     }
     if (!doc['dist-tags']) doc['dist-tags'] = {}
     if (latest) doc["dist-tags"].latest = latest
+
     return ok(doc, "created new entry")
   }
 }


### PR DESCRIPTION
This makes inline attachments possible.
Which means that npm publish will be at minimum only 1 PUT request,
this will eliminate the problem of getting half published modules on flakey networks,
as well as making publishes faster, with fewer round trips.

I also have an implementation of atomic publishes: https://github.com/dominictarr/npm-atomic-publish

I will turn it into a pull request to `npm-registry-client`,
but it's late now, so I'll leave it until after this is merged.
