### PR TITLE
Respect X-Forwarded-Proto header when building tarball URLs.

### DIFF
--- a/registry/shows.js
+++ b/registry/shows.js
@@ -86,7 +86,8 @@ shows.package = function (doc, req) {
           tf = requestedPath.slice(0, i + 1).concat(tf)
         }
         t = '/' + tf.join('/')
-        var h = "http://" + req.headers.Host
+        var proto = req.headers['X-Forwarded-Proto'] || 'http';
+        var h = proto + "://" + req.headers.Host
 
         doc.versions[v].dist.tarball = h + t
       }


### PR DESCRIPTION
We have nginx fronting our registry, and SSL termination is done before the request hits Couch. The problem is the tarball urls built by NPM couchapp are hardcoded to `http://`. We do 301 redirects from http -> https at the nginx layer also, but it would be useful to avoid these round trips. So, I made the tarball URL aware of `X-Forwarded-Proto`. Not sure if this is something you're interested in merging. Let me know!
