### PR TITLE
Adding a view that lists dist-tag.latest for user packages.

### DIFF
--- a/registry/views.js
+++ b/registry/views.js
@@ -422,7 +422,23 @@ views.byUser = { map : function (doc) {
   })
 }}
 
-
+views.byUserLatest = { map: function(doc) {
+  if (!doc || !doc.maintainers || !doc['dist-tags'] || !doc['dist-tags'].latest) return
+  if (doc._id.match(/^npm-test-.+$/) &&
+      doc.maintainers &&
+      doc.maintainers[0].name === 'isaacs')
+    return
+  Array.prototype.forEach = Array.prototype.forEach || function forEach (fn) {
+      for (var i = 0, l = this.length; i < l; i ++) {
+        if (this.hasOwnProperty(i)) {
+          fn(this[i], i, this)
+        }
+      }
+    }
+  doc.maintainers.forEach(function (m) {
+    emit([m.name, doc._id, doc['dist-tags'].latest], 1)
+  })
+}, reduce: '_sum' }
 
 views.browseAuthorsRecent = { map: function (doc) {
   Array.prototype.forEach = Array.prototype.forEach || function forEach (fn) {


### PR DESCRIPTION
Would be nice to see all of my package versions, especially as I'm wanting to get all of them above 1.0.0.

Digging into the testing framework. Don't currently see tests for the other `by-user` views.