### PR TITLE
Bump the timeout for couch to startup to five minutes

### DIFF
--- a/test/00-setup.js
+++ b/test/00-setup.js
@@ -14,7 +14,7 @@ require('./zz-teardown.js')
 // run with the cwd of the main program.
 var cwd = path.dirname(__dirname)
 
-var timeout = process.env.TRAVIS ? 20000 : 5000
+var timeout = 300000; // 5 minutes
 var conf = path.resolve(__dirname, 'fixtures', 'couch.ini')
 var pidfile = path.resolve(__dirname, 'fixtures', 'pid')
 var logfile = path.resolve(__dirname, 'fixtures', 'couch.log')


### PR DESCRIPTION
This is very unlikely to actually fail but also very likely to take
a variable amount of time depending on system load, especicially
under virtualization.

The result has been that on some computers it would fail with the 5 second timeout and Travis would sometimes fail even with a 20 second timeout. This patch bumps it to a 5 minute timeout.
