### PR TITLE
Scoped tarball rewrites

### DIFF
--- a/registry/shows.js
+++ b/registry/shows.js
@@ -80,7 +80,7 @@ shows.package = function (doc, req) {
         // .../_rewrite/pkg/-/pkg-version.tgz
         // or: /pkg/-/pkg-version.tgz
         // depending on what requested path is.
-        var tf = [doc.name, '-', f]
+        var tf = [doc.name.replace(/\//g, '%2f'), '-', f.replace(/\//g, '%2f')]
         var i = requestedPath.indexOf('_rewrite')
         if (i !== -1) {
           tf = requestedPath.slice(0, i + 1).concat(tf)

--- a/registry/shows.js
+++ b/registry/shows.js
@@ -47,7 +47,7 @@ shows.package = function (doc, req) {
 
       var t = doc.versions[v].dist.tarball
       t = t.replace(/^https?:\/\/[^\/:]+(:[0-9]+)?/, '')
-      var f = t.match(/[^\/]+$/)[0]
+      var f = t.match(/(?:@([^\/]+)\/)?[^\/]+$/)[0]
       var requestedPath = req.requested_path
       if (doc._attachments && doc._attachments[f]) {
         // workaround for old couch versions that didn't
@@ -80,7 +80,7 @@ shows.package = function (doc, req) {
         // .../_rewrite/pkg/-/pkg-version.tgz
         // or: /pkg/-/pkg-version.tgz
         // depending on what requested path is.
-        var tf = [doc.name, '-', t.split('/').pop()]
+        var tf = [doc.name, '-', f]
         var i = requestedPath.indexOf('_rewrite')
         if (i !== -1) {
           tf = requestedPath.slice(0, i + 1).concat(tf)

--- a/test/fixtures/scoped-package/package.json
+++ b/test/fixtures/scoped-package/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@scoped/package",
+  "version": "1.2.3"
+}


### PR DESCRIPTION
Tarball rewrite logic was not firing correctly for scoped packages. This fixes it.

It also fixes the issue that tarball links were not escaping the inner '/' in scoped package names, which was confusing route matching.
