### PR TITLE
Prevent empty strings to curl if no auth

### DIFF
--- a/copy.sh
+++ b/copy.sh
@@ -54,7 +54,7 @@ if [ "$auth" != "" ]; then
 fi
 
 curl "$url/_design/scratch" \
-  "${auth[@]}" \
+  ${auth[@]} \
   -k \
   -X COPY \
   -H destination:'_design/app'$rev
@@ -69,7 +69,7 @@ auth="$(node -pe 'require("url").parse(process.argv[1]).auth || ""' "$u")"
 url="$(node -pe 'u=require("url");p=u.parse(process.argv[1]);delete p.auth;u.format(p)' "$u")"
 
 curl "$url/_design/scratch" \
-  "${auth[@]}" \
+  ${auth[@]} \
   -k \
   -X COPY \
   -H destination:'_design/_auth'$rev


### PR DESCRIPTION
If auth is empty, then empty quotes are passed to curl, resulting in an
error of `curl: (3) <url> malformed`. Basically the same as:

```
$ curl google.com ""
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>302 Moved</TITLE></HEAD><BODY>
<H1>302 Moved</H1>
The document has moved
<A HREF="http://www.google.ie/?gws_rd=cr&amp;ei=jjxAVMHbAuLN7Qbyg4HgCQ">here</A>.
</BODY></HTML>
curl: (3) <url> malformed
```

BTW thanks @isaacs for implementing blank auth so quickly!
