### PR TITLE
npm run copy was failing

### DIFF
--- a/copy.sh
+++ b/copy.sh
@@ -67,6 +67,9 @@ if [ "$rev" != "" ]; then
 fi
 auth="$(node -pe 'require("url").parse(process.argv[1]).auth || ""' "$u")"
 url="$(node -pe 'u=require("url");p=u.parse(process.argv[1]);delete p.auth;u.format(p)' "$u")"
+if [ "$auth" != "" ]; then
+  auth=(-u "$auth")
+fi
 
 curl "$url/_design/scratch" \
   "${auth[@]}" \


### PR DESCRIPTION
`npm run copy` was failing due to the credentials being passed to curl being badly formatted.
