### PR TITLE
deploy-version expects `git describe --tags` to work

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -67,8 +67,15 @@ c="$(node -p 'process.argv[1].replace(/\/$/, "")' "$c")"
 u="$(node -p 'require("url").resolve(process.argv[1], "_users")' "$c")"
 
 which couchapp
-DEPLOY_VERSION=`git describe --tags` couchapp push registry/app.js "$c" && \
-DEPLOY_VERSION=`git describe --tags` couchapp push registry/_auth.js "$u" && \
+
+# allow deploy version to be overridden
+# with `DEPLOY_VERSION=testing npm start`.
+if [ "$DEPLOY_VERSION" == "" ]; then
+  DEPLOY_VERSION=`git describe --tags`
+fi
+
+DEPLOY_VERSION="$DEPLOY_VERSION" couchapp push registry/app.js "$c" && \
+DEPLOY_VERSION="$DEPLOY_VERSION" couchapp push registry/_auth.js "$u" && \
 scratch_message && \
 exit 0 || \
 ( ret=$?


### PR DESCRIPTION
deploy-version expects `git describe --tags` to work, this makes running npm-registry-couchapp from a module rather than the GitHub repo difficult.
