### PR TITLE
json is required to run npm-registry-couchapp

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "couchapp": "~0.11.0",
+    "json": "^9.0.2",
     "semver": "4"
   },
   "devDependencies": {


### PR DESCRIPTION
npm-registry-couchapp was operating under the assumption that `json` had been installed globally on the server running npm-registry-couchapp, rather than making this assumption I've explicitly made `json` a dependency.
