### PR TITLE
Add /-/dist-tags endpoints

### DIFF
--- a/registry/rewrites.js
+++ b/registry/rewrites.js
@@ -11,6 +11,14 @@ module.exports =
   , { from: "/-/ping/*", to: "/_show/ping", method: "GET" }
   , { from: "/-/whoami", to: "/_show/whoami", method: "GET" }
 
+
+  , { from: "/-/package/:pkg/dist-tags", to: "/_show/distTags/:pkg", method: "GET" }
+  , { from: "/-/package/:pkg/dist-tags/:tag", to: "/_update/distTags/:pkg", method: "DELETE" }
+  , { from: "/-/package/:pkg/dist-tags/:tag", to: "/_update/distTags/:pkg", method: "PUT" }
+  , { from: "/-/package/:pkg/dist-tags/:tag", to: "/_update/distTags/:pkg", method: "POST" }
+  , { from: "/-/package/:pkg/dist-tags", to: "/_update/distTags/:pkg", method: "PUT" }
+  , { from: "/-/package/:pkg/dist-tags", to: "/_update/distTags/:pkg", method: "POST" }
+
   , { from: "/-/all/since", to:"_list/index/modified", method: "GET" }
 
   , { from: "/-/rss", to: "_list/rss/modified"

--- a/registry/shows.js
+++ b/registry/shows.js
@@ -13,6 +13,16 @@ shows.whoami = function (doc, req) {
   }
 }
 
+shows.distTags = function (doc, req) {
+  return {
+    code: 200,
+    headers: {
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(doc["dist-tags"])
+  }
+}
+
 shows.package = function (doc, req) {
   require("monkeypatch").patch(Object, Date, Array, String)
 

--- a/test/02b-dist-tags.js
+++ b/test/02b-dist-tags.js
@@ -1,0 +1,227 @@
+var common = require('./common.js')
+var path = require('path')
+var url = require('url')
+var test = require('tap').test
+var reg = 'http://127.0.0.1:15986/'
+var request = require('request')
+var db = 'http://localhost:15986/registry/'
+var conf = path.resolve(__dirname, 'fixtures', 'npmrc')
+var dturl = url.resolve(reg, '/-/package/package/dist-tags')
+var auth = 'Basic ' + new Buffer('user:pass@:!%\'').toString('base64')
+var origdt = {
+  latest : "0.2.3",
+  alpha : "0.2.3-alpha"
+}
+
+test('GET dist-tags', function (t) {
+  request({ url: dturl, json: true }, function (er, res, body) {
+    t.same(body, origdt)
+    t.end()
+  })
+})
+
+test('PUT new dist tag set', function (t) {
+  var newdt = {
+    "latest" : "0.2.3",
+    "alpha" : "0.2.3-alpha",
+    "foo": "0.0.2"
+  }
+
+  t.plan(3)
+
+  t.test('fail as anon', function (t) {
+    request.put({
+      url: dturl,
+      body: newdt,
+      json: true
+    }, function (er, res, body) {
+      t.equal(res.statusCode, 403)
+      t.same(body, {
+        error: 'forbidden',
+        reason: 'Please log in before writing to the db'
+      })
+      t.end()
+    })
+  })
+
+  t.test('succeed with auth', function (t) {
+    request.put({
+      url: dturl,
+      body: newdt,
+      headers: {
+        authorization: auth
+      },
+      json: true
+    }, function (er, res, body) {
+      t.equal(res.statusCode, 201)
+      t.same(body, { ok: 'dist-tags updated' })
+      t.end()
+    })
+  })
+
+  t.test('GET after success', function (t) {
+    request({url: dturl, json: true }, function (er, res, body) {
+      t.same(body, newdt)
+      t.end()
+    })
+  })
+})
+
+test('POST new dist tag set', function (t) {
+  var newdt = {
+    latest : "0.2.3-alpha",
+    alpha : "0.2.3-alpha",
+    foo: "0.0.2",
+    blerb: "0.2.3"
+  }
+
+  var post = {
+    latest: "0.2.3-alpha",
+    blerb: "0.2.3"
+  }
+
+  request.post({
+    url: dturl,
+    body: post,
+    headers: {
+      authorization: auth
+    },
+    json: true
+  }, function (er, res, body) {
+    t.equal(res.statusCode, 201)
+    t.same(body, { ok: 'dist-tags updated' })
+    request({ url: dturl, json: true }, function (er, res, body) {
+      t.same(body, newdt)
+      t.end()
+    })
+  })
+})
+
+test('PUT one new tag', function (t) {
+  var newdt = {
+    latest : "0.2.3-alpha",
+    alpha : "0.2.3-alpha",
+    foo: "0.0.2",
+    blerb: "0.0.2"
+  }
+
+  request.put({
+    url: dturl + '/blerb',
+    body: JSON.stringify(newdt.blerb),
+    headers: {
+      authorization: auth
+    }
+  }, function (er, res, body) {
+    body = JSON.parse(body)
+    t.equal(res.statusCode, 201)
+    t.same(body, { ok: 'dist-tags updated' })
+    request({ url: dturl, json: true }, function (er, res, body) {
+      t.same(body, newdt)
+      t.end()
+    })
+  })
+})
+
+test('POST one new tag', function (t) {
+  var newdt = {
+    latest : "0.2.3-alpha",
+    alpha : "0.2.3-alpha",
+    foo: "0.0.2",
+    blerb: "0.2.3"
+  }
+
+  request.post({
+    url: dturl + '/blerb',
+    body: JSON.stringify(newdt.blerb),
+    headers: {
+      authorization: auth
+    }
+  }, function (er, res, body) {
+    body = JSON.parse(body)
+    t.equal(res.statusCode, 201)
+    t.same(body, { ok: 'dist-tags updated' })
+    request({ url: dturl, json: true }, function (er, res, body) {
+      t.same(body, newdt)
+      t.end()
+    })
+  })
+})
+
+test('DELETE blerb tag', function (t) {
+  var newdt = {
+    latest : "0.2.3-alpha",
+    alpha : "0.2.3-alpha",
+    foo: "0.0.2"
+  }
+
+  request.del({
+    url: dturl + '/blerb',
+    headers: {
+      authorization: auth
+    },
+    json: true
+  }, function (er, res, body) {
+    t.equal(res.statusCode, 201)
+    t.same(body, { ok: 'dist-tags updated' })
+    request({ url: dturl, json: true }, function (er, res, body) {
+      t.same(body, newdt)
+      t.end()
+    })
+  })
+})
+
+test('Cannot DELETE latest tag', function (t) {
+  var newdt = {
+    latest : "0.2.3-alpha",
+    alpha : "0.2.3-alpha",
+    foo: "0.0.2"
+  }
+
+  request.del({
+    url: dturl + '/latest',
+    headers: {
+      authorization: auth
+    },
+    json: true
+  }, function (er, res, body) {
+    t.equal(res.statusCode, 403)
+    t.same(body, { error: 'forbidden', reason: 'must have a "latest" dist-tag' })
+    request({ url: dturl, json: true }, function (er, res, body) {
+      t.same(body, newdt)
+      t.end()
+    })
+  })
+})
+
+test('cannot set tag to invalid version', function (t) {
+  request.put({
+    url: dturl + '/latest',
+    headers: {
+      authorization: auth
+    },
+    body: JSON.stringify('999.999.999')
+  }, function (er, res, body) {
+    body = JSON.parse(body)
+    t.equal(res.statusCode, 403)
+    t.same(body, {
+      error: 'forbidden',
+      reason: 'tag points to invalid version: latest'
+    })
+    t.end()
+  })
+})
+
+test('put tags back like we found them', function (t) {
+  request.put({
+    url: dturl,
+    headers: {
+      authorization: auth
+    },
+    json: true,
+    body: origdt
+  }, function (er, res, body) {
+    t.equal(res.statusCode, 201)
+    t.same(body, { ok: 'dist-tags updated' })
+    t.end()
+  })
+})

--- a/test/05-unpublish.js
+++ b/test/05-unpublish.js
@@ -61,7 +61,7 @@ test('GET after unpublish', function(t) {
     res.on('end', function() {
       c = JSON.parse(c)
       // rev and time will be different
-      t.like(c._rev, /13-[0-9a-f]+$/)
+      t.like(c._rev, /[0-9]+-[0-9a-f]+$/)
       expect._rev = c._rev
       t.equal(c.name, c._id)
       t.same(Object.keys(c).sort().join(","),
@@ -153,7 +153,7 @@ test('GET after unpublish', function(t) {
     res.on('end', function() {
       c = JSON.parse(c)
       // rev and time will be different
-      t.like(c._rev, /15-[0-9a-f]+$/)
+      t.like(c._rev, /[0-9]+-[0-9a-f]+$/)
       expect._rev = c._rev
       t.equal(c.name, c._id)
       t.same(Object.keys(c).sort().join(","),


### PR DESCRIPTION
For managing dist-tags explicitly

GET /-/package/:pkg/dist-tags -- returns the package's dist-tags
PUT /-/package/:pkg/dist-tags -- Set package's dist-tags to provided object body (removing missing)
POST /-/package/:pkg/dist-tags -- Add/modify dist-tags from provided object body (merge)
PUT /-/package/:pkg/dist-tags/:tag -- Set package's dist-tags[tag] to provided string body
POST /-/package/:pkg/dist-tags/:tag -- Same as PUT /-/package/:pkg/dist-tags/:tag
DELETE /-/package/:pkg/dist-tags/:tag -- Remove tag from dist-tags
