### PR TITLE
we should not store the access field in CouchDB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: "node_js"
 node_js:
   - "0.10"
-  - "0.11"
+  - "iojs-v1.0.2"
 before_install:
   - "npm config set spin false"
   - "npm install -g npm@^2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: "node_js"
 node_js:
   - "0.10"
-  - "iojs-v1.0.2"
 before_install:
   - "npm config set spin false"
   - "npm install -g npm@^2"

--- a/registry/updates.js
+++ b/registry/updates.js
@@ -305,6 +305,8 @@ updates.package = function (doc, req) {
   // return ok(result, message) to exit successfully at any point.
   // Does some final data integrity cleanup stuff.
   function ok (doc, message) {
+    // access is handled elsewhere, and should not be stored.
+    delete doc.access
     delete doc.mtime
     delete doc.ctime
     var time = doc.time = doc.time || {}

--- a/test/pkg-update-copy-fields.js
+++ b/test/pkg-update-copy-fields.js
@@ -16,6 +16,7 @@ var doc =
   "name": "video.js",
   "description": "foo",
   "readme": "Blerg.",
+  "access": "public",
   "repository": {
     "url": "git://bliorasdf"
   },


### PR DESCRIPTION
The new access flag is sent along in a publication body, but should not be stored in CouchDB. It is intercepted and used elsewhere in the Registry 2.0 system.

CC: @isaacs, @othiym23, does this look like a sane way to nuke the field?