### PR TITLE
Sync test enviroments with npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: "node_js"
 node_js:
+  - iojs
+  - "0.12"
   - "0.10"
+  - "0.8"
 before_install:
   - "npm config set spin false"
-  - "npm install -g npm@^2"
+  - "npm install -g npm@~2"
   - "sudo mkdir -p /var/run/couchdb"
 env:
   - DEPLOY_VERSION=testing

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "bash ./push.sh",
     "load": "bash ./load-views.sh",
     "copy": "bash ./copy.sh",
-    "test": "tap test/*.js"
+    "test": "tap --timeout 60 test/*.js"
   },
   "dependencies": {
     "couchapp": "~0.11.0",


### PR DESCRIPTION
Sync test enviroments with npm for fixing some errors can seems on travis.

Updates:
- Sync test enviroments with npm
- Increase the timeout number for v0.12.x and iojs v1.4.x

If supports v0.8.x, maybe test spends more time on travis. So now I'm thinking other good way..
