### PR TITLE
Makes the tests pass with npm@3

### DIFF
--- a/test/02-publish.js
+++ b/test/02-publish.js
@@ -427,7 +427,7 @@ test('install the thing we published', function(t) {
   })
   c.on('close', function(code) {
     t.notOk(code)
-    t.equal(out, "package@0.2.3 node_modules/package\n")
+    t.similar(out, /^([+] )?package@0.2.3 node_modules[/]package\n$/)
     rimraf.sync(path.resolve(inst, 'node_modules'))
     t.end()
   })

--- a/test/common.js
+++ b/test/common.js
@@ -9,6 +9,9 @@ exports.npm = function (args, opts) {
     args = [exports.npmPath].concat(args)
     cmd = process.execPath
   }
+  if (!opts) opts = {}
+  if (!opts.env) opts.env = {}
+  opts.env.LC_CTYPE = 'UTF-8'
   return spawn(cmd, args, opts)
 }
 


### PR DESCRIPTION
Specifically:

1. Because of better unicode detection, we need to force it to get consistent test output
2. The output of `install` changed due to the need to indicate removals and moves