### PR TITLE
fix copy curl commands for no-auth scenarios

### DIFF
--- a/copy.sh
+++ b/copy.sh
@@ -4,7 +4,7 @@ c=${npm_package_config_couch}
 
 if [ "$c" == "" ]; then
   cat >&2 <<-ERR
-Please set a valid 'npmjs.org:couch' npm config.
+Please set a valid 'npm-registry-couchapp:couch' npm config.
 
 You can put PASSWORD in the setting somewhere to
 have it prompt you for a password each time, so

--- a/copy.sh
+++ b/copy.sh
@@ -50,12 +50,11 @@ fi
 auth="$(node -pe 'require("url").parse(process.argv[1]).auth || ""' "$c")"
 url="$(node -pe 'u=require("url");p=u.parse(process.argv[1]);delete p.auth;u.format(p)' "$c")"
 if [ "$auth" != "" ]; then
-  auth=(-u "$auth")
+  auth=(-u "$auth" )
 fi
 
 curl "$url/_design/scratch" \
-  "${auth[@]}" \
-  -k \
+  "${auth[@]}"-k \
   -X COPY \
   -H destination:'_design/app'$rev
 
@@ -68,11 +67,10 @@ fi
 auth="$(node -pe 'require("url").parse(process.argv[1]).auth || ""' "$u")"
 url="$(node -pe 'u=require("url");p=u.parse(process.argv[1]);delete p.auth;u.format(p)' "$u")"
 if [ "$auth" != "" ]; then
-  auth=(-u "$auth")
+  auth=(-u "$auth" )
 fi
 
 curl "$url/_design/scratch" \
-  "${auth[@]}" \
-  -k \
+  "${auth[@]}"-k \
   -X COPY \
   -H destination:'_design/_auth'$rev

--- a/load-views.sh
+++ b/load-views.sh
@@ -4,7 +4,7 @@ c=${npm_package_config_couch}
 
 if [ "$c" == "" ]; then
   cat >&2 <<-ERR
-Please set a valid 'npmjs.org:couch' npm config.
+Please set a valid 'npm-registry-couchapp:couch' npm config.
 
 You can put PASSWORD in the setting somewhere to
 have it prompt you for a password each time, so


### PR DESCRIPTION
curl—at least the one that ships in the Debian Weezy packages—complains if `$auth` is an empty string. I'm certain there is a more elegant way of solving this issue but this is the one I came up with that worked.

I know of this failure (a no-auth scenario) for reasons. I'm certainly not condoning this behavior. :grinning:

Also, less importantly, there are a couple of references to the old project name. Updated those.