### PR TITLE
add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 [![Build Status](https://img.shields.io/travis/npm/npm-registry-couchapp/master.svg)](https://travis-ci.org/npm/npm-registry-couchapp)
 
+__deprecation notice: as npm has scaled, the registry architecture has gradually migrated towards
+a complex distributed architecture, of which npm-registry-couchapp is only a small part. FOSS
+is an important part of npm, and over time we plan on exposing  more APIs, and [better documenting
+the existing API](https://github.com/npm/public-api).__
+
+__npm-registry-couchapp is still a core part of our functionality, but all new registry features are
+now added to the micro-services that now make up npm. For this reason, we will not be accepting any
+pull requests, or making any changes to this codebase going forward.__
+
 The design doc for The npm Registry CouchApp
 
 # Installing


### PR DESCRIPTION
I feel bad ignoring all the open pull requests on this repo, I've added a deprecation notice that reflects reality:

* we're not entertaining new pull requests or issues, since the registry has migrated towards being a set of micro-services.
* we still want to give the community the data that they need, but this will gradually come in the form of other APIs.