### PR TITLE
[fix] admin password should also be used during `npm run load`

### DIFF
--- a/load-views.sh
+++ b/load-views.sh
@@ -28,6 +28,9 @@ case $c in
   *);;
 esac
 
+c=${c/PASSWORD/$PASSWORD}
+c=${c// /%20}
+
 host="$(node -pe 'require("url").parse(process.argv[1]).host' "$c")"
 hostname="$(node -pe 'require("url").parse(process.argv[1]).hostname' "$c")"
 ips=($(dig +short "$hostname" | egrep '^[0-9]'))


### PR DESCRIPTION
Admin password feature is properly included in `push.sh` and `copy.sh` but is missing two lines in `load-views.sh`.