### PR TITLE
fix insecure install

### DIFF
--- a/www/attachments/install.html
+++ b/www/attachments/install.html
@@ -1,6 +1,6 @@
 <h2>One Line Install</h2>
 
-<code>curl http://npmjs.org/install.sh | sh</code>
+<code>curl https://npmjs.org/install.sh | sh</code>
 
 <h2>More Than One Line Install</h2>
 


### PR DESCRIPTION
The [documentation](https://github.com/npm/npm-registry-couchapp/blob/master/www/attachments/install.html#L3) mentions a one line install command: ```curl http://npmjs.org/install.sh | sh```. It is safer to download via the HTTPS protocol, since http enables main-in-the-middle-attack, and if succeeds in this case, it becomes arbitrary execution attack.