### PR TITLE
remove global check

### DIFF
--- a/registry/validate_doc_update.js
+++ b/registry/validate_doc_update.js
@@ -371,10 +371,6 @@ module.exports = function (doc, oldDoc, user, dbCtx) {
 
   function checkDep(version, dep, t) {
     ridiculousDeps()
-    if (!entity) {
-      assert(scope.isGlobal(dep),
-             "global packages may only depend on other global packages")
-    }
   }
 
   function ridiculousDeps() {

--- a/test/fixtures/vdu/08-throw.json
+++ b/test/fixtures/vdu/08-throw.json
@@ -1,1 +1,1 @@
-{"forbidden":"global packages may only depend on other global packages"}
+{"forbidden":"Changing published version metadata is not allowed"}


### PR DESCRIPTION
Yahoo internal registry is still using this package and right now we're having issue publishing packages that have `dependencies` on public scoped packages. It seems like this check assumes all scoped packages are not global (public). Taking this away means potentially allowing publishing of packages that has private dependencies, which will cause failure during the installation phase, but I couldn't find a way to recursively check each scoped dependency to see what's public and what's not.

If there's any suggestions I'd love to know.