### PR TITLE
use hat for json and parse-json-response

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
   },
   "dependencies": {
     "couchapp": "~0.11.0",
-    "json": "~9.0.2",
+    "json": "^9.0.2",
     "semver": "4"
   },
   "devDependencies": {
     "request": "~2.42.0",
-    "parse-json-response": "~1.0.1",
+    "parse-json-response": "^1.0.1",
     "rimraf": "~2.2.6",
     "tap": "*",
     "which": "~1.0.5"


### PR DESCRIPTION
Fix the error at CI: [builds/297066039](https://travis-ci.org/npm/npm/builds/297066039). My previous patch fixed an issue but made the other error. I apologize for making double work caused by my fault.

I tested this patch with my branch and it worked: [builds/297251441](https://travis-ci.org/npm/npm/builds/297251441).

Refs: https://github.com/npm/npm/pull/18778